### PR TITLE
use correct angular env and dibs test integration script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,24 +1,13 @@
 const gulp = require("gulp");
 const download = require("gulp-download-stream");
 
-const destFolder = "scripts/dibs/";
-const dibsEasyCheckoutName = "dibs-easy-checkout.js";
-
-function downloadDibsTestScript() {
+function downloadDibsScript() {
+	const useTestIntegration =
+		process.env.ANGULAR_ENV !== "production-nb" ? "test." : "";
 	return download({
-		file: dibsEasyCheckoutName,
-		url: "https://test.checkout.dibspayment.eu/v1/checkout.js?v=1",
-	}).pipe(gulp.dest(destFolder));
+		file: "dibs-easy-checkout.js",
+		url: `https://${useTestIntegration}checkout.dibspayment.eu/v1/checkout.js?v=1`,
+	}).pipe(gulp.dest("scripts/dibs/"));
 }
 
-function downloadDibsProdScript() {
-	return download({
-		file: dibsEasyCheckoutName,
-		url: "https://checkout.dibspayment.eu/v1/checkout.js?v=1",
-	}).pipe(gulp.dest(destFolder));
-}
-
-exports.default = downloadDibsTestScript;
-exports.test = downloadDibsTestScript;
-exports.production = downloadDibsProdScript;
-exports.development = downloadDibsTestScript;
+exports.default = downloadDibsScript;

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
 	"version": "1.11.13",
 	"license": "MIT",
 	"scripts": {
-		"dev": "gulp test && ng serve --host 0.0.0.0 --hmr --configuration=nb",
-		"build": "gulp production && ng build --configuration=production-nb",
+		"dev": "gulp && ng serve --host 0.0.0.0 --hmr --configuration=nb",
+		"build": "gulp && ng build --configuration=${ANGULAR_ENV}",
 		"serve": "node server.js",
 		"prettier": "prettier --write '**/*.{html,js,ts,tsx,md,json,yml,css,scss}' --ignore-path=.gitignore",
 		"prettier:check": "prettier --check '**/*.{html,js,ts,tsx,md,json,yml,css,scss}' --ignore-path=.gitignore"


### PR DESCRIPTION
Now, it is possible to use the dibs test integration in both staging and locally. However, it will not currently work for preview deployments. This is because dibs requires you to pass the client url when you send it a payment request. This client uri is set as an .env variable in the api, and thus it is set to either "boklisten.no" (prod) or staging.boklisten.no (staging). This might be able to be fixed in the future, for instance by using the url the api actually received the request from. Nevertheless, this is out of scope for now.
