### PR TITLE
feat: auto extend customer customerItems if already in possesion upon order

### DIFF
--- a/src/app/cart/cart-order-checkout/cart-order-checkout.service.ts
+++ b/src/app/cart/cart-order-checkout/cart-order-checkout.service.ts
@@ -182,10 +182,13 @@ export class CartOrderCheckoutService {
 		const branchIsResponsible = this.branchStoreService.getBranch()
 			?.paymentInfo.responsible;
 
+		const totalPrice = this.cartService.getTotalPrice();
+
 		return (
 			this.cartOrderService.doesOrderIncludeBuy() ||
 			this.cartOrderService.doesOrderIncludeBuyout() ||
-			this.cartOrderService.doesOrderIncludeExtend() ||
+			(this.cartOrderService.doesOrderIncludeExtend() &&
+				totalPrice > 0) ||
 			!branchIsResponsible
 		);
 	}

--- a/src/app/cart/cart.service.ts
+++ b/src/app/cart/cart.service.ts
@@ -18,6 +18,7 @@ import { AuthLoginService } from "@boklisten/bl-login";
 import { Observable } from "rxjs/internal/Observable";
 import { StorageService } from "@boklisten/bl-connect";
 import { GoogleAnalyticsService } from "../GoogleAnalytics/google-analytics.service";
+import { UserCustomerItemService } from "../user/user-customer-item/user-customer-item.service";
 
 export interface CartItem {
 	item: Item;
@@ -41,7 +42,8 @@ export class CartService {
 		private _dateService: DateService,
 		private _authLoginService: AuthLoginService,
 		private _storageService: StorageService,
-		private _googleAnalyticsService: GoogleAnalyticsService
+		private _googleAnalyticsService: GoogleAnalyticsService,
+		private _userCustomerItemService: UserCustomerItemService
 	) {
 		this._cart = [];
 
@@ -177,6 +179,28 @@ export class CartService {
 		}
 
 		this.setPricesOnOrderItem(orderItem, item, period);
+
+		if (this._userCustomerItemService.isExtendableCustomerItem(item.id)) {
+			const customerItem = this._userCustomerItemService.getCustomerItemByItemId(
+				item.id
+			);
+			orderItem.info = {
+				from: new Date(),
+				to: this._dateService.getExtendDate("semester"),
+				numberOfPeriods: 1,
+				periodType: "semester",
+				customerItem: customerItem.id,
+			};
+			orderItem.type = "extend";
+			this.addToCart(
+				item,
+				branchItem,
+				orderItem,
+				this._branchStoreService.getBranch(),
+				customerItem
+			);
+			return;
+		}
 
 		this.addToCart(
 			item,

--- a/src/app/date/date.service.ts
+++ b/src/app/date/date.service.ts
@@ -91,6 +91,8 @@ export class DateService {
 				return rentPeriod.date;
 			}
 		}
+		return branch.paymentInfo.extendPeriods.find((p) => p.type === period)
+			?.date;
 	}
 
 	public onFormat(date: Date, format: string): string {

--- a/src/app/item/item-display/item-display.component.ts
+++ b/src/app/item/item-display/item-display.component.ts
@@ -101,11 +101,13 @@ export class ItemDisplayComponent implements OnInit {
 		}
 
 		try {
-			const haveItem = await this._userCustomerItemService.alreadyHaveItem(
-				itemId
-			);
-			this.alreadyHaveItem = haveItem;
-			if (haveItem && !this._cartService.isCustomerItem(itemId)) {
+			this.alreadyHaveItem =
+				(await this._userCustomerItemService.alreadyHaveItem(itemId)) &&
+				!this._userCustomerItemService.isExtendableCustomerItem(itemId);
+			if (
+				this.alreadyHaveItem &&
+				!this._cartService.isCustomerItem(itemId)
+			) {
 				this._cartService.remove(itemId); // should remove itself if it is apart of cart for some reason
 				this.wait = false;
 			} else {

--- a/src/app/item/item-type-select/item-type-select.component.ts
+++ b/src/app/item/item-type-select/item-type-select.component.ts
@@ -55,6 +55,12 @@ export class ItemTypeSelectComponent implements OnInit {
 		if ((this.isCustomerItem() || this.branchItem) && this.item) {
 			this.displaySelectedPeriodType();
 		}
+
+		// When this component initializes, the cart is empty
+		// Therefore, it needs a little nudge to be be updated when the cart is populated
+		this._cartService.onCartChange().subscribe(() => {
+			this.displaySelectedPeriodType();
+		});
 	}
 
 	public isCustomerItem(): boolean {
@@ -106,6 +112,10 @@ export class ItemTypeSelectComponent implements OnInit {
 	}
 
 	private isActionValid(action: OrderItemType, period?: Period) {
+		const isItemExtendable = this._userCustomerItemService.isExtendableCustomerItem(
+			this.item.id
+		);
+
 		if (
 			action === "partly-payment" &&
 			this.branchItem &&
@@ -125,7 +135,8 @@ export class ItemTypeSelectComponent implements OnInit {
 		} else if (
 			action === "rent" &&
 			this.branchItem &&
-			this.branchItem.rent
+			this.branchItem.rent &&
+			!isItemExtendable
 		) {
 			if (
 				this.branch.paymentInfo.rentPeriods &&
@@ -153,13 +164,14 @@ export class ItemTypeSelectComponent implements OnInit {
 	}
 
 	private calculateOptions() {
+		this.allowedActions = [];
 		let actions: { action: OrderItemType; period?: Period }[] = [
 			{ action: "partly-payment", period: "semester" },
 			{ action: "partly-payment", period: "year" },
 			{ action: "rent", period: "semester" },
 			{ action: "rent", period: "year" },
 			{ action: "buy" },
-			{ action: "extend" },
+			{ action: "extend", period: "semester" },
 			{ action: "buyout" },
 		];
 

--- a/src/app/user/user-customer-item/user-customer-item.service.ts
+++ b/src/app/user/user-customer-item/user-customer-item.service.ts
@@ -94,6 +94,18 @@ export class UserCustomerItemService {
 		});
 	}
 
+	public getCustomerItemByItemId(itemId: string): CustomerItem | undefined {
+		return this.customerItems
+			.filter(() => this.checkIfItemIsInCustomerItems(itemId))
+			.find((customerItem) => customerItem.item === itemId);
+	}
+
+	public isExtendableCustomerItem(itemId: string): boolean {
+		return this.customerItems
+			.filter(() => this.checkIfItemIsInCustomerItems(itemId))
+			.some((customerItem) => this.isExtendValid(customerItem));
+	}
+
 	private checkIfItemIsInCustomerItems(itemId: string): boolean {
 		if (!this.customerItems || this.customerItems.length <= 0) {
 			return false;


### PR DESCRIPTION
Make it so that the if an item in a customer order is already in their possession: extend that item according to the extendPeriod set on the branch.

There are A LOT of ugly code here, because the cart system is really whack. But I tested it with Ullern VG2 ST, by setting an extend period for that branch. (next year, price 0) Then I gave myself a customerItem. Lastly, order the same item as the customerItem, and see the magic happen. 😉