### PR TITLE
feat: redirect to bl-next p2p with token details

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,8 @@ import { WelcomeComponent } from "./welcome/welcome.component";
 import { LocationStrategy, PathLocationStrategy } from "@angular/common";
 import { LogoutComponent } from "./logout/logout.component";
 import { AgreementComponent } from "./agreement/agreement.component";
+import { PeerToPeerLinkerComponent } from "./peer-to-peer-linker/peer-to-peer-linker.component";
+import { UserGuardService } from "./user/user-guard.service";
 
 const routes: Routes = [
 	{
@@ -23,6 +25,11 @@ const routes: Routes = [
 	{
 		path: "agreement",
 		component: AgreementComponent,
+	},
+	{
+		path: "overleveringer",
+		canActivate: [UserGuardService],
+		component: PeerToPeerLinkerComponent,
 	},
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -98,6 +98,7 @@ import * as Sentry from "@sentry/angular";
 import { GoogleAnalyticsService } from "./GoogleAnalytics/google-analytics.service";
 import { AgreementComponent } from "./agreement/agreement.component";
 import { BlCommonModule } from "./bl-common/bl-common.module";
+import { PeerToPeerLinkerComponent } from "./peer-to-peer-linker/peer-to-peer-linker.component";
 
 @NgModule({
 	declarations: [
@@ -107,6 +108,7 @@ import { BlCommonModule } from "./bl-common/bl-common.module";
 		FooterComponent,
 		LogoutComponent,
 		AgreementComponent,
+		PeerToPeerLinkerComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/peer-to-peer-linker/peer-to-peer-linker.component.html
+++ b/src/app/peer-to-peer-linker/peer-to-peer-linker.component.html
@@ -1,0 +1,2 @@
+<h1 class="text-center">Du blir nå videresendt til dine overleveringer.</h1>
+<app-blc-spinner [loading]="true"></app-blc-spinner>

--- a/src/app/peer-to-peer-linker/peer-to-peer-linker.component.spec.ts
+++ b/src/app/peer-to-peer-linker/peer-to-peer-linker.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { PeerToPeerLinkerComponent } from "./peer-to-peer-linker.component";
+
+describe("PeerToPeerLinkerComponent", () => {
+	let component: PeerToPeerLinkerComponent;
+	let fixture: ComponentFixture<PeerToPeerLinkerComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [PeerToPeerLinkerComponent],
+		}).compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(PeerToPeerLinkerComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/peer-to-peer-linker/peer-to-peer-linker.component.ts
+++ b/src/app/peer-to-peer-linker/peer-to-peer-linker.component.ts
@@ -13,6 +13,6 @@ export class PeerToPeerLinkerComponent implements OnInit {
 	ngOnInit(): void {
 		const refreshToken = this._tokenService.getRefreshToken();
 		const accessToken = this._tokenService.getAccessToken();
-		window.location.href = `${environment.nextPath}overleveringer?refresh_token=${refreshToken}&access_token=${accessToken}`;
+		window.location.href = `${environment.nextPath}matches?refresh_token=${refreshToken}&access_token=${accessToken}`;
 	}
 }

--- a/src/app/peer-to-peer-linker/peer-to-peer-linker.component.ts
+++ b/src/app/peer-to-peer-linker/peer-to-peer-linker.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from "@angular/core";
+import { TokenService } from "@boklisten/bl-connect";
+import { environment } from "../../environments/environment";
+
+@Component({
+	selector: "app-peer-to-peer-linker",
+	templateUrl: "./peer-to-peer-linker.component.html",
+	styleUrls: ["./peer-to-peer-linker.component.css"],
+})
+export class PeerToPeerLinkerComponent implements OnInit {
+	constructor(private _tokenService: TokenService) {}
+
+	ngOnInit(): void {
+		const refreshToken = this._tokenService.getRefreshToken();
+		const accessToken = this._tokenService.getAccessToken();
+		window.location.href = `${environment.nextPath}overleveringer?refresh_token=${refreshToken}&access_token=${accessToken}`;
+	}
+}

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -3,6 +3,7 @@ export const environment = {
 	production: false,
 	hmr: false,
 	apiPath: "https://staging.api.boklisten.no/",
+	nextPath: "https://next.boklisten.no/",
 	dibs: {
 		checkoutKey: "test-checkout-key-1a6981e849434c8c90dd382878b4310d",
 		language: "nb-NO",

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -3,6 +3,7 @@ export const environment = {
 	production: false,
 	hmr: true,
 	apiPath: "http://localhost:1337/",
+	nextPath: "http://localhost:3000/",
 	dibs: {
 		checkoutKey: "test-checkout-key-1a6981e849434c8c90dd382878b4310d",
 		language: "nb-NO",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,6 +3,7 @@ export const environment = {
 	production: true,
 	hmr: false,
 	apiPath: "https://api.boklisten.no/",
+	nextPath: "https://next.boklisten.no/",
 	dibs: {
 		checkoutKey: "live-checkout-key-e294063ced7f43b89c58419024a33e79",
 		language: "nb-NO",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,6 +3,7 @@ export const environment = {
 	production: false,
 	hmr: false,
 	apiPath: "https://staging.api.boklisten.no/",
+	nextPath: "https://next.boklisten.no/",
 	dibs: {
 		checkoutKey: "test-checkout-key-1a6981e849434c8c90dd382878b4310d",
 		language: "nb-NO",


### PR DESCRIPTION
`https://boklisten.no/overleveringer` now redirects the user to login (if not already logged in). Then, it redirects the user to `https://next.boklisten.no/overleveringer` with the access and refresh token from bl-web. 

Depends on: https://github.com/boklisten/bl-next/pull/341