### PR TITLE
HOTFIX: error is thrown when trying to order while not logged in due to missing null checks

### DIFF
--- a/src/app/user/user-customer-item/user-customer-item.service.ts
+++ b/src/app/user/user-customer-item/user-customer-item.service.ts
@@ -96,13 +96,13 @@ export class UserCustomerItemService {
 
 	public getCustomerItemByItemId(itemId: string): CustomerItem | undefined {
 		return this.customerItems
-			.filter(() => this.checkIfItemIsInCustomerItems(itemId))
+			?.filter(() => this.checkIfItemIsInCustomerItems(itemId))
 			.find((customerItem) => customerItem.item === itemId);
 	}
 
 	public isExtendableCustomerItem(itemId: string): boolean {
 		return this.customerItems
-			.filter(() => this.checkIfItemIsInCustomerItems(itemId))
+			?.filter(() => this.checkIfItemIsInCustomerItems(itemId))
 			.some((customerItem) => this.isExtendValid(customerItem));
 	}
 


### PR DESCRIPTION
Missing null checks broke the ability to order without being logged in. We need this fix ASAP. 🚅