### PR TITLE
fix(order): soft block go to checkout if userDetails are not valid

### DIFF
--- a/src/app/cart/cart.component.html
+++ b/src/app/cart/cart.component.html
@@ -66,7 +66,11 @@
 	</div>
 	<div class="row justify-content-center">
 		<div class="col-sm-12 col-md-4">
-			<button class="btn btn-success btn-block" routerLink="checkout">
+			<button
+				class="btn btn-success btn-block"
+				routerLink="checkout"
+				[disabled]="!isUserDetailValid"
+			>
 				<fa-icon icon="flag-checkered" class="mr-2"></fa-icon>
 				<span i18n="@@cartCheckoutButton">Checkout</span>
 			</button>

--- a/src/app/cart/cart.component.html
+++ b/src/app/cart/cart.component.html
@@ -59,9 +59,9 @@
 		class="alert alert-warning text-center nav-link"
 	>
 		<fa-icon [icon]="'exclamation-triangle'" class="mr-2"></fa-icon>
-		<a (click)="navigateToUserDetails()"
-			>Du må fylle inn detaljer om deg selv før du kan bestille. Trykk her
-			for å gå til brukerinnstillinger.</a
+		Du må fylle inn detaljer om deg selv før du kan bestille.
+		<a class="bl-link font-weight-bold" (click)="navigateToUserDetails()"
+			>Trykk her for å gå til brukerinnstillinger.</a
 		>
 	</div>
 	<div class="row justify-content-center">

--- a/src/app/item/item-select/item-select.component.html
+++ b/src/app/item/item-select/item-select.component.html
@@ -56,9 +56,9 @@
 		class="alert alert-warning text-center nav-link"
 	>
 		<fa-icon [icon]="'exclamation-triangle'" class="mr-2"></fa-icon>
-		<a (click)="navigateToUserDetails()"
-			>Du må fylle inn detaljer om deg selv før du kan bestille. Trykk her
-			for å gå til brukerinnstillinger.</a
+		Du må fylle inn detaljer om deg selv før du kan bestille.
+		<a class="bl-link font-weight-bold" (click)="navigateToUserDetails()"
+			>Trykk her for å gå til brukerinnstillinger.</a
 		>
 	</div>
 	<div class="row justify-content-center">

--- a/src/app/item/item-select/item-select.component.html
+++ b/src/app/item/item-select/item-select.component.html
@@ -66,6 +66,7 @@
 			<button
 				class="btn btn-success btn-block"
 				routerLink="/cart/checkout"
+				[disabled]="!isUserDetailValid"
 			>
 				<fa-icon icon="flag-checkered" class="mr-2"></fa-icon>
 				<span i18n="@@itemDisplayCategoryCheckout">Checkout</span>


### PR DESCRIPTION
This PR introduces a soft block on the go to checkout buttons, so that the users have to actually register properly in order to finish the order. Will post a hard block in the backend as well, this is just for the pleb facing interface
