### PR TITLE
ci: fail if bl-connect version conflict

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,10 @@ jobs:
                   key: ${{ github.sha }}-install
             - name: prettier
               run: yarn prettier:check
+
+    prevent_bl_connect_version_conflict:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Check bl-connect versions
+              run: '[[ $(yarn why @boklisten/bl-connect | grep "=> Found" --count) -eq 1 ]]'


### PR DESCRIPTION
This will fail the CI if there are two different versions of bl-connect. Crude, but seems to be effective. Have a look at https://github.com/boklisten/bl-web/commits/testlars/ to see it failing. I plan to add this to bl-admin too if you approve.